### PR TITLE
Pequeña corrección

### DIFF
--- a/teoria/tema05-programacion-funcional-swift/tema05-programacion-funcional-swift.md
+++ b/teoria/tema05-programacion-funcional-swift/tema05-programacion-funcional-swift.md
@@ -610,7 +610,7 @@ enum CaracterControlASCII: Character {
 Se puede devolver el valor bruto de la siguiente forma:
 
 ```
-let nuevaLinea = CaracterControlASCII.LineFeed.rawValue
+let nuevaLinea = CaracterControlASCII.lineFeed.rawValue
 ```
 
 También se puede hacer de forma implícita cuando el tipo subyacente es


### PR DESCRIPTION
Fallaba por un carácter que está en mayúscula.